### PR TITLE
Auth error logging

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -39,7 +39,7 @@ export const validateAuth = async (
   try {
     await jose.jwtVerify(jwt, jwk, { subject: clientId, audience: "p0.dev" });
   } catch (error: any) {
-    logger.warn("Error during verification", error.message);
+    logger.error({ clientId, error }, "Error during verification");
     throw new AuthorizationError();
   }
 };


### PR DESCRIPTION
Log `clientId` for better context on errors - we don't know which client is failing when multiple clients/tenants are trying to connect.