### PR TITLE
Define axios interceptors in client once

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -52,6 +52,20 @@ export class JsonRpcClient {
     this.#jsonRpcClient.promise.catch((error: any) =>
       this.#logger.error({ error }, "Error creating JSON RPC client")
     );
+
+    axios.interceptors.request.use((request) => {
+      this.#logger.debug({ request }, "Axios request");
+      return request;
+    });
+
+    axios.interceptors.response.use((response) => {
+      // Do not log response object, it's lengthy and difficult to filter out the authorization header
+      this.#logger.debug(
+        { response: omit(response, "request") },
+        "Axios response"
+      );
+      return response;
+    });
   }
 
   async create() {
@@ -115,20 +129,6 @@ export class JsonRpcClient {
     });
 
     this.#webSocket = clientSocket;
-
-    axios.interceptors.request.use((request) => {
-      this.#logger.debug({ request }, "Axios request");
-      return request;
-    });
-
-    axios.interceptors.response.use((response) => {
-      // Do not log response object, it's lengthy and difficult to filter out the authorization header
-      this.#logger.debug(
-        { response: omit(response, "request") },
-        "Axios response"
-      );
-      return response;
-    });
 
     client.addMethod("call", async (request: ForwardedRequest) => {
       this.#logger.debug({ request }, "forwarded request");


### PR DESCRIPTION
Connections are closed by cloud providers. The client reconnects after each close event. The logging interceptors are added again on each reconnect, which, after enough time, crashes the service when a request comes in.

Example of this happening in logs:
<img width="883" alt="image" src="https://github.com/p0-security/braekhus/assets/5836460/e49ab3e4-f095-48de-8742-2e108375055a">

One request is logged with `msg = "forwarded message"`, and then the interceptor message `message = "Axios request"` is logged hundreds of times (first few is visible in screenshot).