### PR TITLE
Fix docker tagging with "latest"

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,9 +24,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: p0security/braekhus
-          flavor: |
-            latest=auto
-            prefix=v,onlatest=false
+          tags: |
+            type=raw,value=latest
+            type=sha
       - name: Build and push Docker image
         id: docker-build-and-push
         uses: docker/build-push-action@v4


### PR DESCRIPTION
Remove `flavor` property since the output tag doesn't contain `latest` unless used with the `tag` event type, which is currently not in use. 
Simply tag on with `latest` when the workflow runs. Additionally, tag with the commit SHA.