### PR TITLE
Better JQ header name

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -2,7 +2,7 @@ import { Request } from "express";
 import core from "express-serve-static-core";
 import { IncomingHttpHeaders } from "node:http";
 
-export const JQ_HEADER = "braekhus-jq-response-transform";
+export const JQ_HEADER = "braekhus-response-jq-transform";
 
 export type IncomingRequest = Request<
   core.ParamsDictionary,


### PR DESCRIPTION
Because "response-jq-transform" is less ambiguous than "jq-response-transform".