### PR TITLE
Decrease log levels

### DIFF
--- a/client/backoff.ts
+++ b/client/backoff.ts
@@ -65,7 +65,7 @@ export const retryWithBackoff = async <T>(
           return;
         }
         const timeout = backoff.next();
-        logger.info(
+        logger.debug(
           { nextTimeout: timeout, count, error: e },
           "Retrying with backoff timeout"
         );

--- a/server/index.ts
+++ b/server/index.ts
@@ -263,7 +263,7 @@ export class RemoteClientRpcServer extends JsonRpcServer {
 
   onChannelConnection(channelId: ChannelId, channel: JSONRPCServerAndClient) {
     channel.addMethod("setClientId", ({ clientId }) => {
-      this.#logger.info({ channelId, clientId }, "Setting client ID");
+      this.#logger.debug({ channelId, clientId }, "Setting client ID");
       this.addChannel(channelId, clientId);
       return { ok: true };
     });
@@ -325,7 +325,8 @@ export class JsonRpcApp {
         await validateAuth(request.headers.authorization, publicKeyGetter);
         this.#rpcServer.handleUpgrade(request, socket, head);
       })().catch((error: any) => {
-        this.#logger.error({ error }, "Error upgrading connection");
+        // Logged on every attempt from the braekhus proxy to connect, only log with debug level
+        this.#logger.debug({ error }, "Error upgrading connection");
         const body = JSON.stringify({ error }, undefined, 2);
         const code = error.code ?? 500;
         const reason = error.reason ?? "Internal Server Error";


### PR DESCRIPTION
Reduce log spam. Some errors are also logged at debug if they are logged at every connection attempt from the proxy.