### PR TITLE
Multi-arch docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,10 +1,9 @@
 on:
-  pull_request: {}
   workflow_call:
     outputs:
       docker_image_tags:
         description: "Docker image tags"
-        value: ${{ jobs.docker-build-and-push.outputs.docker_image_tags }}
+        value: ${{ jobs.merge-descriptors.outputs.docker_image_tags }}
 
 name: Publish Docker image
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,5 @@
 on:
+  pull_request: {}
   workflow_call:
     outputs:
       docker_image_tags:
@@ -11,30 +12,89 @@ jobs:
   docker-build-and-push:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          # - linux/arm64
 
     steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Extract metadata for Docker
+      - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
+        with:
+          images: p0security/braekhus
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Docker image
+        id: docker-build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=p0security/braekhus,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.docker-build-and-push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-descriptors:
+    name: Merge descriptors
+    runs-on: ubuntu-latest
+    needs: [docker-build-and-push]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
           images: p0security/braekhus
           tags: |
             type=raw,value=latest
             type=sha
-      - name: Build and push Docker image
-        id: docker-build-and-push
-        uses: docker/build-push-action@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'p0security/braekhus@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect p0security/braekhus:${{ steps.meta.outputs.version }}
     outputs:
       docker_image_tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,6 +7,8 @@ on:
 
 name: Publish Docker image
 
+# The job definitions are copied with minimal changes from the Docker documentation: https://docs.docker.com/build/ci/github-actions/multi-platform/
+
 jobs:
   docker-build-and-push:
     name: Push Docker image to Docker Hub
@@ -61,6 +63,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # From each platform job in the matrix of jobs in docker-build-and-push, we get the tags (descriptors)
+  # that were uploaded as artifacts and merge them into a single metadata json.
+  # This job only needs to execute once after all platform builds are completed.
   merge-descriptors:
     name: Merge descriptors
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          # - linux/arm64
+          - linux/arm64
 
     steps:
       - name: Prepare

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 on:
-  # pull_request: {}
+  pull_request: {}
   workflow_call:
 
 name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 on:
-  pull_request: {}
+  # pull_request: {}
   workflow_call:
 
 name: Test


### PR DESCRIPTION
Build Docker images for amd64 (existed) and arm64 (new).
These changes are based on Docker documentation: https://docs.docker.com/build/ci/github-actions/multi-platform/

This PR was tested by executing the GitHub Action from a PR trigger.

New image arm64 version published to DockerHub:

<img width="948" alt="Screenshot 2024-09-05 at 6 15 17 PM" src="https://github.com/user-attachments/assets/f9d56eeb-53d8-4de9-ae1e-5b79da172ecd">

Also: updated 3rd party GitHub Action versions
