### PR TITLE
Improve error reporting to server consumers

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -4,7 +4,7 @@ import {
   JSONRPCServer,
   JSONRPCServerAndClient,
 } from "json-rpc-2.0";
-import { isArray, omit } from "lodash";
+import { omit } from "lodash";
 import { Logger } from "pino";
 import WebSocket from "ws";
 

--- a/log/index.ts
+++ b/log/index.ts
@@ -13,6 +13,7 @@ export const createLogger = <T extends LoggerOptions>(
 ): Logger<T> => {
   const logger = pinoLogger({
     ...options,
+    name: `braekhus.${options.name}`,
     level: process.env.LOG_LEVEL || "info",
     serializers: {
       error: serializeError,

--- a/server/__tests__/e2e.test.ts
+++ b/server/__tests__/e2e.test.ts
@@ -7,9 +7,9 @@ import { JsonRpcClient } from "../../client";
 import { Backoff } from "../../client/backoff";
 import { testHttpServer } from "../testing/testExpressApp";
 
-const SERVER_RPC_PORT = 8080;
-const SERVER_PROXY_PORT = 8081;
-const TARGET_PORT = 8082;
+const SERVER_RPC_PORT = 18080;
+const SERVER_PROXY_PORT = 18081;
+const TARGET_PORT = 18082;
 
 type Client = {
   jsonRpcClient: JsonRpcClient;
@@ -78,7 +78,7 @@ describe("Proxy server starts up first", () => {
       ).resolves.toMatchObject(
         expect.objectContaining({
           status: 502,
-          text: "Bad Gateway",
+          text: '{"error":{"type":"channel_not_found"},"message":"Error: Channel not found: testChannelId"}',
         })
       );
     });
@@ -89,7 +89,7 @@ describe("Proxy server starts up first", () => {
       ).resolves.toMatchObject(
         expect.objectContaining({
           status: 502,
-          text: "Bad Gateway",
+          text: '{"error":{},"message":"Error: Client not found: noSuchClientId"}',
         })
       );
     });

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -78,7 +78,7 @@ export const httpProxyApp = (
         // See See https://nodejs.org/api/stream.html#readablepipedestination-options
         stream.pipe(res);
       } else {
-        res.status(response.status).json(response.data);
+        res.status(response.status).send(response.data);
       }
     } catch (error: any) {
       logger.error({ error, spammy: true }, "Error handling request");
@@ -89,9 +89,9 @@ export const httpProxyApp = (
         (error.message.startsWith("timeout") &&
           error.message.endsWith("exceeded"))
       ) {
-        res.status(504).json({ error });
+        res.status(504).json({ error, message: String(error) });
       } else {
-        res.status(502).json({ error });
+        res.status(502).json({ error, message: String(error) });
       }
     }
   });

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -40,7 +40,7 @@ export const httpProxyApp = (
     const matches = PATH_REGEXP.exec(req.path);
     logger.debug({ matches }, "path matches");
     if (matches === null || matches.length !== 3) {
-      res.sendStatus(400);
+      res.status(404).json({ error: "Invalid path format" });
     }
 
     const clientId = (matches as string[])[1];
@@ -78,7 +78,7 @@ export const httpProxyApp = (
         // See See https://nodejs.org/api/stream.html#readablepipedestination-options
         stream.pipe(res);
       } else {
-        res.status(response.status).send(response.data);
+        res.status(response.status).json(response.data);
       }
     } catch (error: any) {
       logger.error({ error, spammy: true }, "Error handling request");
@@ -89,9 +89,9 @@ export const httpProxyApp = (
         (error.message.startsWith("timeout") &&
           error.message.endsWith("exceeded"))
       ) {
-        res.sendStatus(504);
+        res.status(504).json({ error });
       } else {
-        res.sendStatus(502);
+        res.status(502).json({ error });
       }
     }
   });


### PR DESCRIPTION
Previously we emmitted error codes without any error data. Instead, actually transmit received errors to the Braekhus server consumer.