### PR TITLE
Pass publicKeyGetter from outside runApp

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5,6 +5,7 @@ import { Backoff } from "../client/backoff.js";
 import { JsonRpcClient } from "../client/index.js";
 import { createLogger } from "../log/index.js";
 import { runApp } from "../server/index.js";
+import { ensureKey } from "../server/key-cache.js";
 
 const logger = createLogger({ name: "cli" });
 
@@ -35,6 +36,7 @@ void yargs(hideBin(process.argv))
     (args) => {
       runApp({
         appContext: args,
+        publicKeyGetter: ensureKey,
         forwardedRequestOptions: { timeoutMillis: args.proxyTimeout },
         retryOptions: { startMillis: 250, maxMillis: 2000, maxRetries: 5 },
       });

--- a/server/__tests__/e2e.test.ts
+++ b/server/__tests__/e2e.test.ts
@@ -6,6 +6,7 @@ import { Backoff } from "../../client/backoff.js";
 // TODO replace supertest with axios requests
 import { JsonRpcClient } from "../../client/index.js";
 import { App, InitContext, runApp } from "..//index.js";
+import { ensureKey } from "../key-cache.js";
 import { testHttpServer } from "../testing/testExpressApp.js";
 
 const SERVER_RPC_PORT = 18080;
@@ -20,6 +21,7 @@ type Client = {
 const runServer = (initContext?: InitContext) => {
   return runApp({
     appContext: { rpcPort: SERVER_RPC_PORT, proxyPort: SERVER_PROXY_PORT },
+    publicKeyGetter: ensureKey,
     initContext,
   });
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,7 +22,6 @@ import {
 } from "../types/index.js";
 import { validateAuth } from "./auth.js";
 import { ChannelNotFoundError } from "./error.js";
-import { ensureKey } from "./key-cache.js";
 import { httpProxyApp } from "./proxy.js";
 import { httpError } from "./util.js";
 
@@ -48,6 +47,7 @@ export type App = {
 
 export const runApp = (appParams: {
   appContext: AppContext;
+  publicKeyGetter: PublicKeyGetter;
   initContext?: InitContext;
   callOptions?: CallOptions;
   forwardedRequestOptions?: ForwardedRequestOptions;
@@ -55,6 +55,7 @@ export const runApp = (appParams: {
 }): App => {
   const {
     appContext,
+    publicKeyGetter,
     initContext,
     callOptions,
     forwardedRequestOptions,
@@ -84,7 +85,11 @@ export const runApp = (appParams: {
   const rpcHttpServer = rpcHttpApp.listen(rpcPort, () => {
     logger.info(`HTTP JSON RPC service listening on port ${rpcPort}`);
   });
-  const jsonRpcApp = new JsonRpcApp(rpcHttpServer, ensureKey, initContext);
+  const jsonRpcApp = new JsonRpcApp(
+    rpcHttpServer,
+    publicKeyGetter,
+    initContext
+  );
   const expressApp = httpProxyApp(jsonRpcApp.getRpcServer(), {
     callOptions,
     retryOptions,


### PR DESCRIPTION
Allows other projects that use braekhus as a library to invoke `runApp` with their own `publicKeyGetter`.