### PR TITLE
Update axios dependency to v1.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vitest": "^3.1.3"
   },
   "dependencies": {
-    "axios": "^1.8.3",
+    "axios": "^1.12.2",
     "express": "^4.21.2",
     "jose": "^5.10.0",
     "json-rpc-2.0": "^1.7.0",


### PR DESCRIPTION
Bump axios from version 1.8.3 to 1.12.2 to address CVE https://github.com/advisories/GHSA-4hjh-wcwx-xvwj