### PR TITLE
Update axios to 1.12.2 for CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vitest": "^3.1.3"
   },
   "dependencies": {
-    "axios": "^1.8.3",
+    "axios": "^1.12.2",
     "express": "^4.21.2",
     "jose": "^5.10.0",
     "json-rpc-2.0": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,13 +1089,13 @@ awesome-code-frame@^1.1.0:
     charcodes "^0.2.0"
     js-tokens "^8.0.1"
 
-axios@^1.8.3:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
-  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+axios@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
+  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
   dependencies:
     follow-redirects "^1.15.6"
-    form-data "^4.0.0"
+    form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
 babel-walk@3.0.0-canary-5:
@@ -2222,6 +2222,17 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.12"
+
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 formidable@^2.1.2:


### PR DESCRIPTION
Updating axios to latest version to address a published CVE.
https://github.com/advisories/GHSA-4hjh-wcwx-xvwj