### PR TITLE
Fix stale channel close clobbering a client's live remapped channel

### DIFF
--- a/packages/braekhus/src/server/index.ts
+++ b/packages/braekhus/src/server/index.ts
@@ -259,7 +259,10 @@ export class RemoteClientRpcServer extends JsonRpcServer {
   private removeChannel(channelId: ChannelId) {
     const clientId = this.#clientIds.get(channelId);
     this.#clientIds.delete(channelId);
-    if (clientId) {
+    // Only clear the forward mapping if it still points at this channel.
+    // If the client already reconnected on a new channel, its mapping has
+    // moved on and this (now-stale) channelId must not clobber it.
+    if (clientId && this.#channelIds.get(clientId) === channelId) {
       this.#channelIds.delete(clientId);
     }
   }


### PR DESCRIPTION
## Summary
- Production incident: `RemoteClientRpcServer` was throwing `Client not found: <clientId>` for clients that were actually connected, recurring roughly every ~30 minutes and clearing briefly after a pod restart.
- Root cause: `removeChannel()` unconditionally deleted the forward `clientId -> channelId` mapping whenever *any* channel closed for that client, including a stale channel that had already been superseded by a reconnect. When a client's socket drops (e.g. an idle-timeout disconnect from an intermediate LB/proxy) and it reconnects quickly with a new channel/`setClientId` call, the forward mapping correctly points at the new channel — but if the old channel's `close` event only fires later (there's no active dead-peer detection; see the `healthCheck()` TODO), `removeChannel()` would wipe out the now-current, valid mapping.
- Fix: only clear the forward mapping if it still points at the channel being torn down.

## Test plan
- [x] `yarn build` (tsc) passes
- [ ] `yarn test` (blocked locally by a pre-existing esbuild host/binary version mismatch unrelated to this change; no existing unit tests cover `server/index.ts`)
- [ ] Deploy and confirm `Client not found` errors stop recurring on the ~30 min cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)